### PR TITLE
support constructing DB and Tx from existing standard library types

### DIFF
--- a/db.go
+++ b/db.go
@@ -118,6 +118,11 @@ func (db *DB) Begin() (*Tx, error) {
 	return &Tx{db.newBuilder(tx), tx}, nil
 }
 
+// Wrap encapsulates an existing transaction.
+func (db *DB) Wrap(sqlTx *sql.Tx) *Tx {
+	return &Tx{db.newBuilder(sqlTx), sqlTx}
+}
+
 // Transactional starts a transaction and executes the given function.
 // If the function returns an error, the transaction will be rolled back.
 // Otherwise, the transaction will be committed.

--- a/db.go
+++ b/db.go
@@ -61,6 +61,17 @@ var BuilderFuncMap = map[string]BuilderFunc{
 	"oci8":     NewOciBuilder,
 }
 
+// NewFromDB encapsulates an existing database connection.
+func NewFromDB(sqlDB *sql.DB, driverName string) *DB {
+	db := &DB{
+		driverName:  driverName,
+		sqlDB:       sqlDB,
+		FieldMapper: DefaultFieldMapFunc,
+	}
+	db.Builder = db.newBuilder(db.sqlDB)
+	return db
+}
+
 // Open opens a database specified by a driver name and data source name (DSN).
 // Note that Open does not check if DSN is specified correctly. It doesn't try to establish a DB connection either.
 // Please refer to sql.Open() for more information.
@@ -70,14 +81,7 @@ func Open(driverName, dsn string) (*DB, error) {
 		return nil, err
 	}
 
-	db := &DB{
-		driverName:  driverName,
-		sqlDB:       sqlDB,
-		FieldMapper: DefaultFieldMapFunc,
-	}
-	db.Builder = db.newBuilder(db.sqlDB)
-
-	return db, nil
+	return NewFromDB(sqlDB, driverName), nil
 }
 
 // MustOpen opens a database and establishes a connection to it.

--- a/db_test.go
+++ b/db_test.go
@@ -5,6 +5,7 @@
 package dbx
 
 import (
+	"database/sql"
 	"errors"
 	"io/ioutil"
 	"strings"
@@ -18,6 +19,15 @@ const (
 	TestDSN     = "travis:@/ozzo_dbx_test?parseTime=true"
 	FixtureFile = "testdata/mysql.sql"
 )
+
+func TestDB_NewFromDB(t *testing.T) {
+	sqlDB, err := sql.Open("mysql", TestDSN)
+	if assert.Nil(t, err) {
+		db := NewFromDB(sqlDB, "mysql")
+		assert.NotNil(t, db.sqlDB)
+		assert.NotNil(t, db.FieldMapper)
+	}
+}
 
 func TestDB_Open(t *testing.T) {
 	db, err := Open("mysql", TestDSN)


### PR DESCRIPTION
I have an existing application where I'd like to try using ozzo in some areas.  This application already creates a `sql.DB` on its own, and manages its own transaction lifecycle with the `sql.DB.Begin` and `sql.Tx.{Commit,Rollback}` methods.  I would like to be able to simply wrap the ozzo helpers around the standard library structs without having to change the application to use ozzo everywhere.