### PR TITLE
Enable `RenameTable`, `RenameColumn` and `DropColumn` in the sqlite builder

### DIFF
--- a/builder_sqlite.go
+++ b/builder_sqlite.go
@@ -74,18 +74,10 @@ func (b *SqliteBuilder) TruncateTable(table string) *Query {
 	return b.NewQuery(sql)
 }
 
-// DropColumn creates a Query that can be used to drop a column from a table.
-func (b *SqliteBuilder) DropColumn(table, col string) *Query {
-	q := b.NewQuery("")
-	q.LastError = errors.New("SQLite does not support dropping columns")
-	return q
-}
-
-// RenameColumn creates a Query that can be used to rename a column in a table.
-func (b *SqliteBuilder) RenameColumn(table, oldName, newName string) *Query {
-	q := b.NewQuery("")
-	q.LastError = errors.New("SQLite does not support renaming columns")
-	return q
+// RenameTable creates a Query that can be used to rename a table.
+func (b *SqliteBuilder) RenameTable(oldName, newName string) *Query {
+	sql := fmt.Sprintf("ALTER TABLE %v RENAME TO %v", b.db.QuoteTableName(oldName), b.db.QuoteTableName(newName))
+	return b.NewQuery(sql)
 }
 
 // AlterColumn creates a Query that can be used to change the definition of a table column.

--- a/builder_sqlite_test.go
+++ b/builder_sqlite_test.go
@@ -39,6 +39,12 @@ func TestSqliteBuilder_TruncateTable(t *testing.T) {
 	assert.Equal(t, q.SQL(), "DELETE FROM `users`", "t1")
 }
 
+func TestSqliteBuilder_RenameTable(t *testing.T) {
+	b := getSqliteBuilder()
+	q := b.RenameTable("usersOld", "usersNew")
+	assert.Equal(t, q.SQL(), "ALTER TABLE `usersOld` RENAME TO `usersNew`", "t1")
+}
+
 func TestSqliteBuilder_DropColumn(t *testing.T) {
 	b := getSqliteBuilder()
 	q := b.DropColumn("users", "age")

--- a/builder_sqlite_test.go
+++ b/builder_sqlite_test.go
@@ -45,18 +45,6 @@ func TestSqliteBuilder_RenameTable(t *testing.T) {
 	assert.Equal(t, q.SQL(), "ALTER TABLE `usersOld` RENAME TO `usersNew`", "t1")
 }
 
-func TestSqliteBuilder_DropColumn(t *testing.T) {
-	b := getSqliteBuilder()
-	q := b.DropColumn("users", "age")
-	assert.NotEqual(t, q.LastError, nil, "t1")
-}
-
-func TestSqliteBuilder_RenameColumn(t *testing.T) {
-	b := getSqliteBuilder()
-	q := b.RenameColumn("users", "name", "username")
-	assert.NotEqual(t, q.LastError, nil, "t1")
-}
-
 func TestSqliteBuilder_AlterColumn(t *testing.T) {
 	b := getSqliteBuilder()
 	q := b.AlterColumn("users", "name", "int")

--- a/query_test.go
+++ b/query_test.go
@@ -121,6 +121,17 @@ func TestQuery_Rows(t *testing.T) {
 		assert.Equal(t, customers[2].Status, 2, "customers[2].Status")
 	}
 
+	// Query.All() with slice of pointers
+	var customersPtrSlice []*Customer
+	sql = `SELECT * FROM customer ORDER BY id`
+	err = db.NewQuery(sql).All(&customersPtrSlice)
+	if assert.Nil(t, err) {
+		assert.Equal(t, len(customersPtrSlice), 3, "len(customersPtrSlice)")
+		assert.Equal(t, customersPtrSlice[2].ID, 3, "customersPtrSlice[2].ID")
+		assert.Equal(t, customersPtrSlice[2].Email, `user3@example.com`, "customersPtrSlice[2].Email")
+		assert.Equal(t, customersPtrSlice[2].Status, 2, "customersPtrSlice[2].Status")
+	}
+
 	var customers2 []NullStringMap
 	err = db.NewQuery(sql).All(&customers2)
 	if assert.Nil(t, err) {

--- a/rows.go
+++ b/rows.go
@@ -124,6 +124,12 @@ func (r *Rows) all(slice interface{}) error {
 		return r.Close()
 	}
 
+	var isSliceOfPointers bool
+	if et.Kind() == reflect.Ptr {
+		isSliceOfPointers = true
+		et = et.Elem()
+	}
+
 	if et.Kind() != reflect.Struct {
 		return VarTypeError("must be a slice of struct or NullStringMap")
 	}
@@ -144,6 +150,11 @@ func (r *Rows) all(slice interface{}) error {
 		if err := r.Scan(refs...); err != nil {
 			return err
 		}
+
+		if isSliceOfPointers {
+			ev = ev.Addr()
+		}
+
 		v.Set(reflect.Append(v, ev))
 	}
 


### PR DESCRIPTION
SQLite 3 has ALTER TABLE support for most of the schema modify operations - https://www.sqlite.org/lang_altertable.html

This PR enables in the `builder_sqlite.go`:
- `RenameTable`
- `RenameColumn` (the same syntax as the default builder)
- `DropColumn` (the same syntax as the default builder)