### PR TITLE
Added 'sqlite' key to db.BuilderFuncMap for noncgo sqlite driver support

### DIFF
--- a/db.go
+++ b/db.go
@@ -73,6 +73,7 @@ type (
 // You may modify this variable to add the builder support for a new DB driver.
 // If a DB driver is not listed here, the StandardBuilder will be used.
 var BuilderFuncMap = map[string]BuilderFunc{
+	"sqlite":   NewSqliteBuilder,
 	"sqlite3":  NewSqliteBuilder,
 	"mysql":    NewMysqlBuilder,
 	"postgres": NewPgsqlBuilder,


### PR DESCRIPTION
The noncgo sqlite driver (https://pkg.go.dev/modernc.org/sqlite) uses `sqlite` as driver key.
This PR adds the key to the `db.BuilderFuncMap`, so that users don't have to do:

```go
func init() {
    dbx.BuilderFuncMap["sqlite"] = dbx.BuilderFuncMap["sqlite3"]
}
```